### PR TITLE
[E-PPER] 7일차

### DIFF
--- a/sukyeongs/EPPER/11399-p.py
+++ b/sukyeongs/EPPER/11399-p.py
@@ -1,0 +1,9 @@
+# BOJ - 11399 ATM (solution 함수 버전)
+
+def solution(n, line):
+    line.sort()
+
+    for i in range(1, n):
+        line[i] += line[i-1]
+    
+    return sum(line)

--- a/sukyeongs/EPPER/42628.py
+++ b/sukyeongs/EPPER/42628.py
@@ -1,5 +1,5 @@
 # Programmers - 42628 이중우선순위큐
-from heapq import heappush, heappop
+from heapq import heappush, heappop, heapify
 
 def solution(operations):
     hq = []
@@ -12,6 +12,7 @@ def solution(operations):
             if hq:
                 if num == '1':
                     hq.remove(max(hq))
+                    heapify(hq)
                     continue
                 else:
                     heappop(hq)

--- a/sukyeongs/EPPER/42628.py
+++ b/sukyeongs/EPPER/42628.py
@@ -1,0 +1,25 @@
+# Programmers - 42628 이중우선순위큐
+from heapq import heappush, heappop
+
+def solution(operations):
+    hq = []
+    for operation in operations:
+        cmd, num = operation.split()
+        if cmd == 'I':
+            heappush(hq, int(num))
+            continue
+        else:
+            if hq:
+                if num == '1':
+                    hq.remove(max(hq))
+                    continue
+                else:
+                    heappop(hq)
+                    continue
+            else:
+                continue
+    if hq:
+        return [max(hq), min(hq)]
+    
+    else:
+        return [0,0]

--- a/sukyeongs/Programmers/42628.py
+++ b/sukyeongs/Programmers/42628.py
@@ -1,5 +1,5 @@
 # Programmers - 42628 이중우선순위큐
-from heapq import heappush, heappop
+from heapq import heappush, heappop, heapify
 
 def solution(operations):
     hq = []
@@ -12,6 +12,7 @@ def solution(operations):
             if hq:
                 if num == '1':
                     hq.remove(max(hq))
+                    heapify(hq)
                     continue
                 else:
                     heappop(hq)

--- a/sukyeongs/Programmers/42628.py
+++ b/sukyeongs/Programmers/42628.py
@@ -1,0 +1,25 @@
+# Programmers - 42628 이중우선순위큐
+from heapq import heappush, heappop
+
+def solution(operations):
+    hq = []
+    for operation in operations:
+        cmd, num = operation.split()
+        if cmd == 'I':
+            heappush(hq, int(num))
+            continue
+        else:
+            if hq:
+                if num == '1':
+                    hq.remove(max(hq))
+                    continue
+                else:
+                    heappop(hq)
+                    continue
+            else:
+                continue
+    if hq:
+        return [max(hq), min(hq)]
+    
+    else:
+        return [0,0]


### PR DESCRIPTION
### 7일차

- Programmers - 42628 이중우선순위큐

----

### Issue
문제를 단순하게 풀고 테스트케이스까지 통과해서 맞는 로직인 줄 알았으나,  
`heapq` 모듈을 사용할 때, `list` 원소를 삭제할 때 사용하는 `remove` 함수를 같이 사용해버리면  
`heapq`로 원소를 넣고 삭제한 **우선순위큐의 순서에 이상이 생긴다** 고 한다.  


우선순위큐의 순서를 해치지 않고 해당 큐의 최댓값을 삭제하는 로직을 다시 깊이 생각해보아야 할 것 같다.

### Solution
`heapify()` 메소드를 활용하여 우선순위큐를 다시 정렬해주면 된다고 한다!  
```python
heapify(hq)
```

`remove()` 메소드를 사용한 후에 `heapify()` 메소드를 호출하여 우선순위큐를 다시 정렬해주었다.